### PR TITLE
Add optional thiserror derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A no-std, no-alloc set of tools for protobuf encoding and decodin
 repository = "https://github.com/dflemstr/femtopb"
 categories = ["embedded", "encoding", "no-std", "no-std::no-alloc"]
 keywords = ["protobuf", "proto"]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -15,6 +15,7 @@ license = "Apache-2.0"
 femtopb-derive = { path = "derive", version = "0.6.1" }
 no-panic = { version = "0.1.30", optional = true }
 defmt = { version = "0.3.8", optional = true }
+thiserror-no-std = { version = "2.0.2", optional = true }
 
 [dev-dependencies]
 bytes = "1.7.0"
@@ -31,6 +32,7 @@ prost = "0.13.1"
 # reasons.
 assert-no-panic = ["dep:no-panic"]
 defmt = ["dep:defmt"]
+thiserror = ["dep:thiserror-no-std"]
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A no-std, no-alloc set of tools for protobuf encoding and decodin
 repository = "https://github.com/dflemstr/femtopb"
 categories = ["embedded", "encoding", "no-std", "no-std::no-alloc"]
 keywords = ["protobuf", "proto"]
-version = "0.6.2"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 //! Common error type definitions
 
-use core::fmt;
-use thiserror_no_std::Error;
 use crate::encoding;
 
 /// A Protobuf message decoding error.
@@ -10,7 +8,7 @@ use crate::encoding;
 /// Protobuf message. The error details should be considered 'best effort': in
 /// general it is not possible to exactly pinpoint why data is malformed.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "thiserror", derive(Error))]
+#[cfg_attr(feature = "thiserror", derive(thiserror_no_std::Error))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum DecodeError {
@@ -58,24 +56,14 @@ pub enum DecodeError {
 /// provided buffer had insufficient capacity. Message encoding is otherwise
 /// infallible.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "thiserror", derive(Error))]
+#[cfg_attr(feature = "thiserror", derive(thiserror_no_std::Error))]
+#[cfg_attr(feature = "thiserror", error("encode error: required {required} bytes but only {remaining} remaining"))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct EncodeError {
     /// How much space was required for the encode operation to complete
     pub required: usize,
     /// How much space actually remains in the buffer
     pub remaining: usize,
-}
-
-#[cfg(feature = "thiserror")]
-impl fmt::Display for EncodeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "encode error: required {} bytes but only {} remaining",
-            self.required, self.remaining
-        )
-    }
 }
 
 impl EncodeError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
 //! Common error type definitions
+
+use core::fmt;
+use thiserror_no_std::Error;
 use crate::encoding;
 
 /// A Protobuf message decoding error.
@@ -7,6 +10,7 @@ use crate::encoding;
 /// Protobuf message. The error details should be considered 'best effort': in
 /// general it is not possible to exactly pinpoint why data is malformed.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "thiserror", derive(Error))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum DecodeError {
@@ -54,12 +58,24 @@ pub enum DecodeError {
 /// provided buffer had insufficient capacity. Message encoding is otherwise
 /// infallible.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "thiserror", derive(Error))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct EncodeError {
     /// How much space was required for the encode operation to complete
     pub required: usize,
     /// How much space actually remains in the buffer
     pub remaining: usize,
+}
+
+#[cfg(feature = "thiserror")]
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "encode error: required {} bytes but only {} remaining",
+            self.required, self.remaining
+        )
+    }
 }
 
 impl EncodeError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 //! Common error type definitions
-
 use crate::encoding;
 
 /// A Protobuf message decoding error.

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,16 +13,23 @@ use crate::encoding;
 pub enum DecodeError {
     /// We were unable to decode a varint, because the last byte overflowed a 64-bit integer; the
     /// buffer is likely corrupt.
+    #[cfg_attr(feature = "thiserror", error("Unable to decode varint: the last byte overflowed a 64-bit integer. The buffer is likely corrupt"))]
     InvalidVarint,
     /// The decoded varint was larger than expected; the too-large value is enclosed.
+    #[cfg_attr(feature = "thiserror", error("Varint larger than expected: {0}"))]
     VarintTooLarge(u64),
     /// The provided buffer was too short to be able to decode the desired data.
+    #[cfg_attr(feature = "thiserror", error("Provided buffer is too short"))]
     BufferUnderflow,
     /// An end group tag was encountered without a matching start group tag.
+    #[cfg_attr(feature = "thiserror", error("End group tag encountered without matching start group tag"))]
     UnexpectedEndGroupTag,
     /// The specified wire type value was too large; the too-large value is enclosed.
+    #[cfg_attr(feature = "thiserror", error("Wire type value too large: {0}"))]
     InvalidWireTypeValue(u64),
     /// We expected a different wire type value than the one that was encountered.
+    #[cfg_attr(feature = "thiserror",
+        error("Unexpected wire type: {}. Expected: {}", *actual as u8, *expected as u8))]
     UnexpectedWireTypeValue {
         /// The encountered wire type from the decoded buffer.
         actual: encoding::WireType,
@@ -34,15 +41,22 @@ pub enum DecodeError {
     },
     /// The encountered tag was different from the one we were expecting; the wrong tag value is
     /// enclosed.
+    #[cfg_attr(feature = "thiserror", error("Unexpected tag value: {0}"))]
     UnexpectedTagValue(u32),
     /// The encountered key value was out of range; the out-of-range value is enclosed.
+    #[cfg_attr(feature = "thiserror", error("Key value out of range: {0}"))]
     InvalidKeyValue(u64),
     /// The encountered tag value was out of range; the out-of-range value is enclosed.
     ///
     /// This is different from `InvalidKeyValue` in the sense that the key had a valid wire type,
     /// but invalid field tag value.
+    #[cfg_attr(feature = "thiserror", error("Key value out of range: {0}"))]
     InvalidTagValue(u32),
     /// The encountered string field does not contain valid UTF-8 data.
+    #[cfg_attr(feature = "thiserror",
+        error("Invalid UTF-8 data: Valid up to {}. Error length: {}",
+            valid_up_to,
+            error_len.map_or("N/A", |value| "{value}")))]
     InvalidUtf8 {
         valid_up_to: usize,
         error_len: Option<usize>,


### PR DESCRIPTION
This PR adds an optional `thiserror` feature flag which enables [`thiserror_no_std`](https://docs.rs/thiserror-no-std/latest/thiserror_no_std/) derives for `DecodeError` and `EncodeError`. 